### PR TITLE
Adiciona datas de criação e conclusão às tarefas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ venv/
 __pycache__/
 *.pyc
 .env
+.pytest_cache

--- a/README.md
+++ b/README.md
@@ -11,11 +11,20 @@ python src/cli.py --add "Estudar Python"
 # Listar tarefas
 python src/cli.py --list
 
+# Listar tarefas com detalhes
+python src/cli.py --list --verbose
+
 # Listar tarefas concluídas
 python src/cli.py --list --filter completed
 
 # Listar tarefas pendentes
 python src/cli.py --list --filter pending
+
+# Filtrar tarefas criadas antes de uma data
+python src/cli.py --list --created-before 2025-01-31
+
+# Filtrar tarefas concluídas após uma data
+python src/cli.py --list --completed-after 2025-01-31
 
 # Remover tarefa (por índice)
 python src/cli.py --remove 0

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import datetime
 from todo import ToDoList
 
 
@@ -17,6 +18,17 @@ def main():
     parser.add_argument(
         "--complete", type=int, help="Marcar tarefa como concluída pelo índice"
     )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Mostrar detalhes completos das tarefas"
+    )
+    parser.add_argument(
+        "--created-before",
+        help="Filtrar tarefas criadas antes de uma data (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--completed-after",
+        help="Filtrar tarefas concluídas após uma data (YYYY-MM-DD)",
+    )
     args = parser.parse_args()
 
     if args.add:
@@ -29,10 +41,44 @@ def main():
 
     if args.list:
         tasks = todo.list_tasks(args.filter)
+
+        if args.created_before:
+            tasks = [
+                t
+                for t in tasks
+                if datetime.fromisoformat(t["created_at"])
+                < datetime.strptime(args.created_before, "%Y-%m-%d")
+            ]
+
+        if args.completed_after:
+            tasks = [
+                t
+                for t in tasks
+                if t["completed"]
+                and datetime.fromisoformat(t["completed_at"])
+                > datetime.strptime(args.completed_after, "%Y-%m-%d")
+            ]
+
         if tasks:
             for idx, task in enumerate(tasks):
                 status = "X" if task["completed"] else " "
-                print(f"{idx}. [{status}] {task['task']}")
+                created = datetime.fromisoformat(task["created_at"]).strftime(
+                    "%d/%m/%Y %H:%M"
+                )
+                completed = (
+                    datetime.fromisoformat(task["completed_at"]).strftime(
+                        "%d/%m/%Y %H:%M"
+                    )
+                    if task["completed_at"]
+                    else "N/A"
+                )
+
+                if args.verbose:
+                    print(f"{idx}. [{status}] {task['task']}")
+                    print(f"\tCriada em: {created}")
+                    print(f"\tConcluída em: {completed}\n")
+                else:
+                    print(f"{idx}. [{status}] {task['task']}")
         else:
             print("Nenhuma tarefa encontrada!")
 

--- a/src/todo.py
+++ b/src/todo.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime
 
 
 class ToDoList:
@@ -26,7 +27,12 @@ class ToDoList:
             json.dump(self.tasks, f, indent=4)
 
     def add_task(self, task: str) -> None:
-        self.tasks.append({"task": task, "completed": False})
+        self.tasks.append({
+            "task": task, 
+            "completed": False,
+            "created_at": datetime.now().isoformat(),
+            "completed_at": None
+            })
         self.__save_tasks()
 
     def list_tasks(self, filter_status: str = "all") -> list:
@@ -49,6 +55,7 @@ class ToDoList:
     def mark_as_completed(self, index: int) -> bool:
         try:
             self.tasks[index]["completed"] = True
+            self.tasks[index]["completed_at"] = datetime.now().isoformat()
             self.__save_tasks()
             return True
         except IndexError:

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -28,3 +28,16 @@ def test_list_tasks(todo: ToDoList):
     pending_tasks = todo.list_tasks(filter_status="pending")
     assert len(pending_tasks) == 1
     assert pending_tasks[0]["task"] == "Tarefa 2"
+
+
+def test_task_creation_date(todo):
+    todo.add_task("Tarefa com data")
+    assert "created_at" in todo.tasks[0]
+    assert isinstance(todo.tasks[0]["created_at"], str)
+
+
+def test_task_completion_date(todo):
+    todo.add_task("Tarefa para concluir")
+    todo.mark_as_completed(0)
+    assert "completed_at" in todo.tasks[0]
+    assert isinstance(todo.tasks[0]["completed_at"], str)


### PR DESCRIPTION
**Closes #2**

**Descrição:**
Este PR implementa o armazenamento de datas de criação (`created_at`) e conclusão (`completed_at`) das tarefas, além de novos filtros na CLI.

### Mudanças Principais:
- **Persistência de Datas:**
    - Campo `created_at` (`datetime ISO`) adicionado automaticamente ao criar tarefas;
    - Campo `completed_at` é preenchido ao marcar tarefas como concluídas.
- **Novos Filtros na CLI:**
    - `--created-before <DATA>`: Filtra tarefas criadas antes de data especificada (formato: `YYYY-MM-DD`);
    - `--completed-after <DATA>`: Filtra tarefas concluídas após a data especificada (apenas para tarefas concluídas).
- **Saída Verbosa:**
    - Opção `--verbose` exibe datas formatadas (`DD/MM/YYYY HH:MM`)

### Como Testar:
```bash
# Adicionar tarefa e marcar como concluída
python src/cli.py --add "Revisar PRs"
python src/cli.py --complete 0

# Listar com detalhes
python src/cli.py --list --verbose

# Filtrar tarefas criadas antes de 2025-01-31
python src/cli.py --list --created-before 2025-01-31

# Filtrar e listar com detalhes
python src/cli.py --list --verbose --created-before 2025-01-31
```