### PR TITLE
fix: Correção de índices ao usar filtros na listagem de tarefas (Closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ python src/cli.py --remove 0
 python src/cli.py --complete 0
 ```
 
+### Importante
+
+Ao usar filtros (`--filter`, `--created-before`, etc.), os índices exibidos são **reais** (referentes à lista completa).
+Use esses índices para remover/editar tarefas, mesmo após filtrar.
+
 ## Requisitos
 
 - Python 3.8+

--- a/src/cli.py
+++ b/src/cli.py
@@ -33,12 +33,12 @@ def main():
         "--priority",
         choices=["alta", "media", "baixa"],
         default="baixa",
-        help="Definir prioridade de tarefa (alta/media/baixa)"
+        help="Definir prioridade de tarefa (alta/media/baixa)",
     )
     parser.add_argument(
         "--filter-priority",
         choices=["alta", "media", "baixa"],
-        help="Filtrar tarefas por prioridade"
+        help="Filtrar tarefas por prioridade",
     )
     args = parser.parse_args()
 
@@ -74,10 +74,13 @@ def main():
                 > datetime.strptime(args.completed_after, "%Y-%m-%d")
             ]
 
+        real_indexes = [idx for idx, task in enumerate(todo.tasks) if task in tasks]
         if tasks:
-            for idx, task in enumerate(tasks):
+            for display_idx, (real_indexes, task) in enumerate(
+                zip(real_indexes, tasks)
+            ):
                 status = "X" if task["completed"] else " "
-                priority = f"[{task['priority'].upper()}]"
+                priority = f"[{task['priority'].upper()}]" if "priority" in task else ""
                 created = datetime.fromisoformat(task["created_at"]).strftime(
                     "%d/%m/%Y %H:%M"
                 )
@@ -90,11 +93,13 @@ def main():
                 )
 
                 if args.verbose:
-                    print(f"{idx}. {priority} [{status}] {task['task']}")
+                    print(
+                        f"Índice Real: {real_indexes} | Tarefa {display_idx}: {priority} [{status}] {task['task']}"
+                    )
                     print(f"\tCriada em: {created}")
                     print(f"\tConcluída em: {completed}\n")
                 else:
-                    print(f"{idx}. {priority} [{status}] {task['task']}")
+                    print(f"{real_indexes}. {priority} [{status}] {task['task']}")
         else:
             print("Nenhuma tarefa encontrada!")
 

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -62,3 +62,19 @@ def test_filter_by_priority(todo):
 
     assert len(high_priority_tasks) == 1
     assert high_priority_tasks[0]["task"] == "Tarefa 1"
+
+
+def test_remove_task_with_filters(todo):
+    todo.add_task("Tarefa Alta", Priority.HIGH)
+    todo.add_task("Tarefa Baixa", Priority.LOW)
+
+    filtered_tasks = [
+        task for task in todo.tasks if task["priority"] == Priority.LOW.value
+    ]
+    real_indices = [
+        idx for idx, task in enumerate(todo.tasks) if task in filtered_tasks
+    ]
+
+    assert todo.remove_task(real_indices[0]) is True
+    assert len(todo.tasks) == 1
+    assert todo.tasks[0]["priority"] == Priority.HIGH.value


### PR DESCRIPTION
Closes #10

Este _PR_ resolve um bug crítico onde os índices exibidos após aplicar filtros (`--filter`, `--filter-priority`, etc.), não correspondiam aos índices reais na lista completa, causando remoção/edição de tarefas incorretas.

### Mudanças Principais
Agora, os índices exibidos sempre refletem a posição real na lista completa, mesmo quando filtros são aplicados.